### PR TITLE
Update service-portal-submission-approval.xml

### DIFF
--- a/task/routines/service-portal-submission-approval.xml
+++ b/task/routines/service-portal-submission-approval.xml
@@ -86,7 +86,7 @@ attributes = JSON.parse(@results['Retrieve Created By User']['Attributes Map JSO
 if(attributes.has_key?('Manager') &amp;&amp; !attributes['Manager'].empty?)
   output = attributes['Manager'][0]
 end
-outupt%&gt;</parameter>
+output%&gt;</parameter>
                 </parameters>
                 <messages>
                     <message type="Complete"></message>


### PR DESCRIPTION
output was misspelled causing the following error when manager approval

The "input" parameter of the "Manager Username from User Attribute" node could not be evaluated due to a NameError.

  PROBLEM:
  undefined local variable or method `outupt' within current binding.

  PARAMETER TEMPLATE:
  1: <%=
  2: output = "Default"
  3: attributes = JSON.parse(@results['Retrieve Created By User']['Attributes Map JSON'])
  4: if(attributes.has_key?('Manager') && !attributes['Manager'].empty?)
  5:   output = attributes['Manager'][0]
  6: end
  7: outupt%>