### PR TITLE
Update submissions---services.submitted.xml

### DIFF
--- a/task/sources/kinetic-request-ce/trees/submissions---services.submitted.xml
+++ b/task/sources/kinetic-request-ce/trees/submissions---services.submitted.xml
@@ -140,7 +140,7 @@ outcome%&gt;</parameter>
             <task definition_id="routine_kinetic_submission_update_status_v1" id="routine_kinetic_submission_update_status_v1_66" name="Status - Approval - Denied" x="342" y="-66">
                 <version>1</version>
                 <configured>true</configured>
-                <defers>false</defers>
+                <defers>true</defers>
                 <deferrable>true</deferrable>
                 <visible>false</visible>
                 <parameters>


### PR DESCRIPTION
Changed the node "Status - Approval - Denied" to defer.  When it doesn't defer sometimes the status will change to closed in the "Close Submission" node first.  This causes an error stating the status cannot be changed to denied but cause the record is already closed.