### PR TITLE
Update service-portal-submission-config.xml

### DIFF
--- a/task/routines/service-portal-submission-config.xml
+++ b/task/routines/service-portal-submission-config.xml
@@ -153,7 +153,7 @@ most_significant_value(data, key, default_value)%&gt;</parameter>
 # Configure Key and Default Value
 #
 key = 'Task Assignee Team'
-default_value = 'default'
+default_value = 'Default'
 
 # Finds the most significant, cascaded, non-nil value for a given key.
 #


### PR DESCRIPTION
'Task Assignee Team' was set to "default" should be "Default". Workflow later in the process converts this value to a has to match up with the Team Name using the API. The two values return different values, causing the generated hash to not match the team.